### PR TITLE
Add capability to collect code coverage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,26 @@
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
     },
+    "@types/events": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
+      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g=="
+    },
+    "@types/glob": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
+      "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+      "requires": {
+        "@types/events": "*",
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/minimatch": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
+    },
     "@types/mocha": {
       "version": "2.2.48",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.48.tgz",
@@ -48,8 +68,7 @@
     "@types/node": {
       "version": "8.10.42",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.42.tgz",
-      "integrity": "sha512-8LCqostMfYwQs9by1k21/P4KZp9uFQk3Q528y3qtPKQnCJmKz0Em3YzgeNjTNV1FVrG/7n/6j12d4UKg9zSgDw==",
-      "dev": true
+      "integrity": "sha512-8LCqostMfYwQs9by1k21/P4KZp9uFQk3Q528y3qtPKQnCJmKz0Em3YzgeNjTNV1FVrG/7n/6j12d4UKg9zSgDw=="
     },
     "@types/sinon": {
       "version": "4.3.3",
@@ -3412,9 +3431,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mississippi": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -265,6 +265,11 @@
           "type": "boolean",
           "default": false,
           "description": "If true, test coverage runs will include test assemblies in the coverage result"
+        },
+        "dotnet-test-explorer.coverageFilePath": {
+          "type": "string",
+          "default": "",
+          "description": "A workspace-relative path where the coverage result files should be placed (must be a directory)"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -98,11 +98,15 @@
       },
       {
         "command": "dotnet-test-explorer.debugTest",
-        "title": "Debug Test"
+        "title": "Debug Test(s)"
       },
       {
         "command": "dotnet-test-explorer.openPanel",
         "title": "Open Tests Panel"
+      },
+      {
+        "command": "dotnet-test-explorer.coverTest",
+        "title": "Cover Test(s)"
       }
     ],
     "menus": {
@@ -148,6 +152,11 @@
           "command": "dotnet-test-explorer.debugTest",
           "when": "view == dotnetTestExplorer",
           "group": "dotnetTestExplorer@2"
+        },
+        {
+          "command": "dotnet-test-explorer.coverTest",
+          "when": "view == dotnetTestExplorer",
+          "group": "dotnetTestExplorer@3"
         }
       ],
       "editor/context": [
@@ -251,6 +260,11 @@
           "type": "boolean",
           "default": false,
           "description": "If true, displays test duration in both the test list and code lens"
+        },
+        "dotnet-test-explorer.includeTestAssemblyCoverage": {
+          "type": "boolean",
+          "default": false,
+          "description": "If true, test coverage runs will include test assemblies in the coverage result"
         }
       }
     },
@@ -295,6 +309,7 @@
     "webpack-cli": "^3.3.11"
   },
   "dependencies": {
+    "@types/glob": "^7.1.1",
     "applicationinsights": "^1.0.5",
     "fkill": "^5.3.0",
     "glob": "^7.1.2",

--- a/resources/coverlet.runsettings
+++ b/resources/coverlet.runsettings
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat code coverage">
+        <Configuration>
+          <Format>lcov</Format>
+          <Exclude>[coverlet.*.tests?]*,[*]Coverlet.Core*</Exclude>
+          <ExcludeByAttribute>Obsolete,GeneratedCodeAttribute,CompilerGeneratedAttribute</ExcludeByAttribute>
+          <IncludeTestAssembly>INCLUDE_TESTS_TOKEN</IncludeTestAssembly>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,7 +20,7 @@ import { Utility } from "./utility";
 export function activate(context: vscode.ExtensionContext) {
     const testResults = new TestResultsFile();
     const testDirectories = new TestDirectories();
-    const testCommands = new TestCommands(testResults, testDirectories);
+    const testCommands = new TestCommands(context, testResults, testDirectories);
     const gotoTest = new GotoTest();
     const findTestInContext = new FindTestInContext();
     const problems = new Problems(testCommands);
@@ -85,6 +85,10 @@ export function activate(context: vscode.ExtensionContext) {
 
     context.subscriptions.push(vscode.commands.registerCommand("dotnet-test-explorer.runTest", (test: TestNode) => {
         testCommands.runTest(test);
+    }));
+
+    context.subscriptions.push(vscode.commands.registerCommand("dotnet-test-explorer.coverTest", (test: TestNode) => {
+        testCommands.coverTest(test);
     }));
 
     context.subscriptions.push(vscode.commands.registerTextEditorCommand("dotnet-test-explorer.runTestInContext", (editor: vscode.TextEditor) => {

--- a/src/findTestInContext.ts
+++ b/src/findTestInContext.ts
@@ -19,13 +19,13 @@ export class FindTestInContext {
             symbolCandidate = symbolsInRange.find( (s) => s.documentSymbol.kind === vscode.SymbolKind.Method);
 
             if (symbolCandidate) {
-                return {testName: (symbolCandidate.fullName), isSingleTest: true};
+                return {testName: (symbolCandidate.fullName), isSingleTest: true, collectCoverage: false};
             }
 
             symbolCandidate = symbolsInRange.find( (s) => s.documentSymbol.kind === vscode.SymbolKind.Class);
 
             if (symbolCandidate) {
-                return {testName: symbolCandidate.fullName, isSingleTest: false};
+                return {testName: symbolCandidate.fullName, isSingleTest: false, collectCoverage: false};
             }
         });
     }


### PR DESCRIPTION
Adds a new menu item to run selected tests with code coverage.

The test projects need to have the coverlet.collector nuget package installed for coverage to work. Coverage results are outputted into the same temp folder as the test results. Format is lcov. After the result file is created it is copied into the workspace being tested. Path within the workspace can be configured.

Verified it works with the coverage-gutters extension - coverage is displayed and updated when the coverage file changes.

Fixes #3 