### PR TITLE
Perform nested class comprehension while flattening

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -100,7 +100,7 @@
               "--extensionTestsPath=${workspaceFolder}/out/test"
             ],
             "outFiles": ["${workspaceFolder}/out/test/**/*.js"],
-            "preLaunchTask": "npm: test-compile"
+            "preLaunchTask": "test-compile"
           }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -36,6 +36,24 @@
             "problemMatcher": [
                 "$tslint5"
             ]
+        },
+        {
+            "label": "test-compile",
+            "command": "npm",
+            "type": "shell",
+            "args": [
+                "run",
+                "test-compile"
+            ],
+            "problemMatcher": [
+                "$tsc"
+            ],
+            "presentation": {
+                "reveal": "never",
+                "revealProblems": "onProblem",
+                "clear": true
+            },
+            "group": "build"
         }
     ]
 }

--- a/src/findTestInContext.ts
+++ b/src/findTestInContext.ts
@@ -4,7 +4,7 @@ import { ITestRunContext } from './testCommands';
 
 export class FindTestInContext {
   public async find(doc: vscode.TextDocument, position: vscode.Position): Promise<ITestRunContext | undefined> {
-    return Symbols.getSymbols(doc.uri, true).then((documentSymbols: Array<ITestSymbol>) => {
+    return Symbols.getSymbols(doc.uri).then((documentSymbols: Array<ITestSymbol>) => {
       const symbolsInRange = documentSymbols.filter(ds => ds.documentSymbol.range.contains(position));
 
       let symbolCandidate: ITestSymbol | undefined;

--- a/src/gotoTest.ts
+++ b/src/gotoTest.ts
@@ -48,7 +48,7 @@ export class GotoTest {
     const candidates: Map<string, ITestSymbolLocation> = new Map<string, ITestSymbolLocation>();
 
     for (let i = 0; i < symbols.length; ++i) {
-      const docSymbols = await Symbols.getSymbols(symbols[i].location.uri, true);
+      const docSymbols = await Symbols.getSymbols(symbols[i].location.uri);
 
       const candidate = docSymbols.find(ts => this.isSymbolATestCandidate(symbols[i]) && ts.fullName === testNode.fqn);
 

--- a/src/testStatusCodeLensProvider.ts
+++ b/src/testStatusCodeLensProvider.ts
@@ -54,7 +54,7 @@ export class TestStatusCodeLensProvider implements CodeLensProvider {
     const results = this.testResults;
     const showDuration = Utility.getConfiguration().get<boolean>('showTestDuration');
 
-    return Symbols.getSymbols(document.uri, true).then((symbols: Array<ITestSymbol>) => {
+    return Symbols.getSymbols(document.uri).then((symbols: Array<ITestSymbol>) => {
       const mapped: Array<CodeLens> = [];
       for (const symbol of symbols.filter(x => x.documentSymbol.kind === SymbolKind.Method)) {
         for (const result of results.values()) {

--- a/test/gotoTest.test.ts
+++ b/test/gotoTest.test.ts
@@ -35,7 +35,7 @@ suite('Find test location', () => {
     ];
 
     getSymbolsStub
-      .withArgs(symbols[0].location.uri, sinon.match.bool)
+      .withArgs(symbols[0].location.uri)
       .returns(Promise.resolve(testSymbols));
 
     const testNode = new TestNode('Test', 'Test', '', [], []);
@@ -53,7 +53,7 @@ suite('Find test location', () => {
     ];
 
     getSymbolsStub
-      .withArgs(symbols[0].location.uri, sinon.match.bool)
+      .withArgs(symbols[0].location.uri)
       .returns(Promise.resolve(testSymbols));
 
     const testNode = new TestNode('Test', 'Test', '', [], []);
@@ -75,7 +75,7 @@ suite('Find test location', () => {
     ];
 
     getSymbolsStub
-      .withArgs(symbols[0].location.uri, sinon.match.bool)
+      .withArgs(symbols[0].location.uri)
       .returns(Promise.resolve(testSymbols));
 
     const testNode = new TestNode('Test with spaces', 'Test with spaces', '', [], []);
@@ -120,7 +120,7 @@ suite('Find test location', () => {
     ];
 
     for (let i = 0; i < symbols.length; ++i) {
-      getSymbolsStub.withArgs(symbols[i].location.uri, sinon.match.bool).returns(Promise.resolve([testSymbols[i]]));
+      getSymbolsStub.withArgs(symbols[i].location.uri).returns(Promise.resolve([testSymbols[i]]));
     }
 
     const testNode = new TestNode('Test', 'Test', '', [], []);
@@ -141,7 +141,7 @@ suite('Find test location', () => {
     ];
 
     for (let i = 0; i < symbols.length; ++i) {
-      getSymbolsStub.withArgs(symbols[i].location.uri, sinon.match.bool).returns(Promise.resolve([testSymbols[i]]));
+      getSymbolsStub.withArgs(symbols[i].location.uri).returns(Promise.resolve([testSymbols[i]]));
     }
 
     const testNode = new TestNode('Test', 'Test', '', [], []);
@@ -166,7 +166,7 @@ suite('Find test location', () => {
     ];
 
     for (let i = 0; i < symbols.length; ++i) {
-      getSymbolsStub.withArgs(symbols[i].location.uri, sinon.match.bool).returns(Promise.resolve([testSymbols[i]]));
+      getSymbolsStub.withArgs(symbols[i].location.uri).returns(Promise.resolve([testSymbols[i]]));
     }
 
     const testNode = new TestNode('Test', 'Test', '', [], []);
@@ -191,7 +191,7 @@ suite('Find test location', () => {
     ];
 
     for (let i = 0; i < symbols.length; ++i) {
-      getSymbolsStub.withArgs(symbols[i].location.uri, sinon.match.bool).returns(Promise.resolve([testSymbols[i]]));
+      getSymbolsStub.withArgs(symbols[i].location.uri).returns(Promise.resolve([testSymbols[i]]));
     }
 
     const testNode = new TestNode('Test', 'Test', '', [], []);

--- a/test/symbols.test.ts
+++ b/test/symbols.test.ts
@@ -20,44 +20,44 @@ suite('Flattend symbols', () => {
 
     myNamespace.children = [myClass];
 
-    const flattened = Symbols.flatten([myNamespace], false, '');
+    const flattened = Symbols.flatten([myNamespace], '', false);
 
-    assert.equal(flattened.length, 7);
+    assert.strictEqual(flattened.length, 7);
 
-    assert.equal(flattened[0].fullName, 'MyNameSpace');
-    assert.equal(flattened[0].parentName, '');
+    assert.strictEqual(flattened[0].fullName, 'MyNameSpace');
+    assert.strictEqual(flattened[0].parentName, '');
 
-    assert.equal(flattened[1].fullName, 'MyNameSpace.MyClass');
-    assert.equal(flattened[1].parentName, 'MyNameSpace');
+    assert.strictEqual(flattened[1].fullName, 'MyNameSpace.MyClass');
+    assert.strictEqual(flattened[1].parentName, 'MyNameSpace');
 
-    assert.equal(flattened[2].fullName, 'MyNameSpace.MyClass.MyMethodOne');
-    assert.equal(flattened[2].parentName, 'MyNameSpace.MyClass');
+    assert.strictEqual(flattened[2].fullName, 'MyNameSpace.MyClass.MyMethodOne');
+    assert.strictEqual(flattened[2].parentName, 'MyNameSpace.MyClass');
 
-    assert.equal(flattened[3].fullName, 'MyNameSpace.MyClass.MyMethodTwo');
-    assert.equal(flattened[3].parentName, 'MyNameSpace.MyClass');
+    assert.strictEqual(flattened[3].fullName, 'MyNameSpace.MyClass.MyMethodTwo');
+    assert.strictEqual(flattened[3].parentName, 'MyNameSpace.MyClass');
 
-    assert.equal(flattened[4].fullName, 'MyNameSpace.MyClass+MyNestedClass');
-    assert.equal(flattened[4].parentName, 'MyNameSpace.MyClass');
+    assert.strictEqual(flattened[4].fullName, 'MyNameSpace.MyClass+MyNestedClass');
+    assert.strictEqual(flattened[4].parentName, 'MyNameSpace.MyClass');
 
-    assert.equal(flattened[5].fullName, 'MyNameSpace.MyClass+MyNestedClass.MyMethodOne');
-    assert.equal(flattened[5].parentName, 'MyNameSpace.MyClass+MyNestedClass');
+    assert.strictEqual(flattened[5].fullName, 'MyNameSpace.MyClass+MyNestedClass.MyMethodOne');
+    assert.strictEqual(flattened[5].parentName, 'MyNameSpace.MyClass+MyNestedClass');
 
-    assert.equal(flattened[6].fullName, 'MyNameSpace.MyClass+MyNestedClass.MyMethodTwo');
-    assert.equal(flattened[6].parentName, 'MyNameSpace.MyClass+MyNestedClass');
+    assert.strictEqual(flattened[6].fullName, 'MyNameSpace.MyClass+MyNestedClass.MyMethodTwo');
+    assert.strictEqual(flattened[6].parentName, 'MyNameSpace.MyClass+MyNestedClass');
   });
 
   test('Can remove arguments to test methods', () => {
     const myMethod = GetDocumentSymbol('MyMethodOne', vscode.SymbolKind.Method);
 
-    let flattened = Symbols.flatten([myMethod], false, '');
+    let flattened = Symbols.flatten([myMethod], '', false);
 
-    assert.equal(flattened[0].fullName, 'MyMethodOne');
+    assert.strictEqual(flattened[0].fullName, 'MyMethodOne');
 
     const myMethodWithArguments = GetDocumentSymbol('MyMethodOne(TestCase: Something)', vscode.SymbolKind.Method);
 
-    flattened = Symbols.flatten([myMethodWithArguments], true, '');
+    flattened = Symbols.flatten([myMethodWithArguments], '', false);
 
-    assert.equal(flattened[0].fullName, 'MyMethodOne');
+    assert.strictEqual(flattened[0].fullName, 'MyMethodOne');
   });
 });
 


### PR DESCRIPTION
Instead of having two passes - one for tree flattening and one for nested class comprehension, we now do both at the same time.